### PR TITLE
Store parsed fields in an array of struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ RM = rm -fv
 PRG       = lh_parser
 SRCS      = lhp_args.c lhp_parse.c main.c
 OBJS      = $(subst .c,.o,$(SRCS))
-LAS_FILE  = ver_line_30.las
+LAS_FILE  = ver_lines_30.las
 
 
 # ------------------------------------------------------------------------------
@@ -62,6 +62,9 @@ $(DIR_REL)/$(PRG): $(SRCS)
 	$(CC) $(CFLAGS) $^ -o $(DIR_REL)/$(PRG)
 
 run_rel:
+	@echo "#----------------------------------------#"
+	@echo "LAS_FILE: [$(LAS_FILE)]"
+	@echo "#----------------------------------------#"
 	./$(DIR_REL)/$(PRG) -f $(DIR_DATA)/3.0/$(LAS_FILE)
 
 clean_rel:

--- a/examples/3.0/ver_line_30.las
+++ b/examples/3.0/ver_line_30.las
@@ -1,1 +1,0 @@
-VERS.                          3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0

--- a/examples/3.0/ver_lines_30.las
+++ b/examples/3.0/ver_lines_30.las
@@ -1,0 +1,3 @@
+ VERS.                          3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0
+ WRAP.                           NO : ONE LINE PER DEPTH STEP
+ DLM .                        COMMA : DELIMITING CHARACTER BETWEEN DATA COLUMNS 


### PR DESCRIPTION
Resolves #8 `Refactor : move individual field variables to a record_struct{}`

- Move parsed metadata fields to an array of structs
- Rename makefile and ver_line_30.las