### PR TITLE
Enable parsing Section headers and comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ RM = rm -fv
 PRG       = lh_parser
 SRCS      = lhp_args.c lhp_parse.c main.c
 OBJS      = $(subst .c,.o,$(SRCS))
-LAS_FILE  = ver_lines_30.las
+LAS_FILE  = dev_example_30.las
 
 
 # ------------------------------------------------------------------------------

--- a/examples/3.0/dev_example_30.las
+++ b/examples/3.0/dev_example_30.las
@@ -1,0 +1,7 @@
+~VERSION INFORMATION
+ VERS.                          3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0
+ WRAP.                           NO : ONE LINE PER DEPTH STEP
+ DLM .                        COMMA : DELIMITING CHARACTER BETWEEN DATA COLUMNS 
+# Acceptable delimiting characters: SPACE (default), TAB, OR COMMA.
+~Well Information
+ STRT .M              1670.0000                : First Index Value


### PR DESCRIPTION
This pull-request enables reading Section headers (~...)  and comments (#...) without panicking.


Here is the output of a test run using the test file: dev_example_30.las

```bash
./build/rel/lh_parser -f examples/3.0/dev_example_30.las
filename: [examples/3.0/dev_example_30.las]
Section Type: [~VERSION INFORMATION]

Section Type: [~Well Information]

#----------------------------------------#
Record: [0]
#----------------------------------------#
Mnemonic: [ VERS]
Unit: []
Value: [3.0 ]
Description: [CWLS LOG ASCII STANDARD -VERSION 3.0]
#----------------------------------------#
Record: [1]
#----------------------------------------#
Mnemonic: [ WRAP]
Unit: []
Value: [NO ]
Description: [ONE LINE PER DEPTH STEP]
#----------------------------------------#
Record: [2]
#----------------------------------------#
Mnemonic: [ DLM ]
Unit: []
Value: [COMMA ]
Description: [DELIMITING CHARACTER BETWEEN DATA COLUMNS]
#----------------------------------------#
Record: [3]
#----------------------------------------#
Mnemonic: [ STRT ]
Unit: [M]
Value: [1670.0000                ]
Description: [First Index Value]
```
