### PR TITLE
Issue 9 refactor parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ GCC_VER = 9
 CC      = /usr/local/opt/gcc/bin/gcc-$(GCC_VER)
 COV     = /usr/local/opt/gcc/bin/gcov-$(GCC_VER)
 CFLAGS  = -Wall -Wextra -Wpedantic -pedantic-errors -I include
+# CFLAGS  = -Wall -Wextra -Wpedantic -Werror -pedantic-errors -I include
+# Check memory issues
+# CFLAGS  = -Wall -Wextra -Wpedantic -pedantic-errors -fsanitize=address -g -O0 -I include
 
 
 # ------------------------------------------------------------------------------
@@ -28,7 +31,7 @@ RM = rm -fv
 # Project variables
 # ------------------------------------------------------------------------------
 PRG       = lh_parser
-SRCS      = lhp_args.c lhp_parse.c main.c
+SRCS      = lhp_args.c lhp_file.c lhp_line.c lhp_metadata.c lhp_parse.c main.c
 OBJS      = $(subst .c,.o,$(SRCS))
 LAS_FILE  = dev_example_30.las
 

--- a/include/lhp_file.h
+++ b/include/lhp_file.h
@@ -1,0 +1,27 @@
+/*
+ * File-Name: lhp_file.h
+ * File-Desc: header file for file services in lhp_file.c
+ * App-Name: lh_parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+
+#ifndef LH_FILE_H
+#define LH_FILE_H
+
+
+
+/* public structs : start */
+struct LhpFile {
+  FILE *fp;
+  size_t size;
+};
+/* public structs : finis */
+
+/* public-functions */
+extern void lhp_file_init(struct LhpFile* lhpfile, const char *lhp_filename);
+/* end public-functions */
+
+#endif /* LH_PARSE_H */

--- a/include/lhp_line.h
+++ b/include/lhp_line.h
@@ -1,0 +1,28 @@
+/*
+ * File-Name: lhp_line.h
+ * File-Desc: header file for line services in lh_parse
+ * App-Name: lh_parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+#ifndef LH_LINE_H
+#define LH_LINE_H
+
+#include <stdio.h>
+
+/* public structs : start */
+struct LhpLine {
+  char *line;
+  size_t idx;
+  size_t size;
+};
+/* public structs : finis */
+
+/* public-functions */
+extern void lhp_line_init(struct LhpLine* lhpline);
+extern void lhp_line_config(struct LhpLine* lhpline);
+/* end public-functions */
+
+#endif /* LH_LINE_H */

--- a/include/lhp_metadata.h
+++ b/include/lhp_metadata.h
@@ -1,0 +1,35 @@
+/*
+ * File-Name: lhp_metadata.h
+ * File-Desc: header file for metadata services in lh_parse
+ * App-Name: lh_parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+#ifndef LH_METADATA_H
+#define LH_METADATA_H
+
+#include "lhp_line.h"
+
+/* public structs */
+struct LhpMetadata {
+  char* mnemonic_name;
+  char* unit;
+  char* value;
+  char* desc;
+};
+
+struct LhpData {
+  struct LhpMetadata* array;
+  size_t len;
+};
+/* end public structs */
+
+/* public-functions */
+extern struct LhpMetadata* lhp_metadata_init(size_t size);
+extern void lhp_data_init(struct LhpData* lhpdata, size_t size);
+extern void parse_data_line(struct LhpMetadata* lhp_metadata, struct LhpLine* line);
+/* end public-functions */
+
+#endif /* LH_METADATA_H */

--- a/include/lhp_parse.h
+++ b/include/lhp_parse.h
@@ -12,7 +12,7 @@
 
 
 /* public-functions */
-void read_las_file(const char *lhp_filename);
+void parse_las_file(const char *lhp_filename);
 /* end public-functions */
 
 #endif /* PQ_PARSE_H */

--- a/src/lhp_file.c
+++ b/src/lhp_file.c
@@ -1,0 +1,66 @@
+/*
+ * File-Name: lhp_file.c
+ * File-Desc: file and line services for lh_parser
+ * App-Name: lh_parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+#include <stdio.h> // FILE, fclose(), fopen(), fprintf(), perror()
+#include <stdlib.h> // exit()
+#include <errno.h>
+
+#include <string.h> // strerror
+#include <sys/stat.h>
+#include <sys/types.h>
+
+
+#include "lhp_file.h"
+
+static FILE *lhp_file_open(const char *lhp_filename);
+static off_t lhp_file_get_size(const char *lhp_filename);
+
+
+// ---------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------
+void lhp_file_init(struct LhpFile* lhpfile, const char *lhp_filename)
+{
+  lhpfile->fp = lhp_file_open(lhp_filename);
+  lhpfile->size = lhp_file_get_size(lhp_filename);
+  
+  printf("FILESIZE: [%zu]\n", lhpfile->size);
+}
+
+
+// ---------------------------------------------------------------------
+// Support functions
+// ---------------------------------------------------------------------
+static FILE *lhp_file_open(const char *lhp_filename)
+{
+  FILE *result;
+  result = fopen(lhp_filename, "r");
+
+  if (result == NULL)
+  {
+    fprintf(
+      stdout,
+      "INFO: could not open '%s' for reading", lhp_filename);
+    perror("fopen");
+  }
+  return result;
+}
+
+static off_t lhp_file_get_size(const char *filename) {
+  struct stat st;
+
+  if (stat(filename, &st) == 0)
+      return st.st_size;
+
+  fprintf(stderr, "Cannot determine size of %s: %s\n",
+          filename, strerror(errno));
+  exit(EXIT_FAILURE);
+
+  return -1;
+}

--- a/src/lhp_line.c
+++ b/src/lhp_line.c
@@ -1,0 +1,54 @@
+/*
+ * File-Name: lhp_line.c
+ * File-Desc: line buffer services for lh_parse
+ * App-Name: lh_parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> // strlen()
+#include <ctype.h> // iscntrl(), isspace()
+
+#include "lhp_line.h"
+
+static void lhp_clean_eol(struct LhpLine* lhpline);
+
+// --------------------------------------------------------
+// API functions
+// --------------------------------------------------------
+// struct LhpLine* lhp_line_init(void) {
+void lhp_line_init(struct LhpLine* lhpline) {
+  lhpline->size = 2048;
+  lhpline->line = malloc(lhpline->size);
+  lhpline->idx = 0;
+}
+
+void lhp_line_config(struct LhpLine* lhpline) {
+  lhpline->idx = 0;
+  lhp_clean_eol(lhpline);
+
+  // Skip spaces at the beginning of the string.
+  while (isspace(lhpline->line[lhpline->idx])) {
+    lhpline->idx++;
+  }
+}
+
+// --------------------------------------------------------
+// Internal functions
+// --------------------------------------------------------
+static void lhp_clean_eol(struct LhpLine* lhpline)
+{
+    // Remove spaces and new-lines from the end of the line
+    size_t line_len = strlen(lhpline->line);
+    for (size_t idx = line_len ; idx >= 1; idx--) {
+        if (iscntrl(lhpline->line[idx]) || isspace(lhpline->line[idx])) {
+            lhpline->line[idx] = '\0';
+        }
+        else {
+            break;
+        }
+    }
+}

--- a/src/lhp_metadata.c
+++ b/src/lhp_metadata.c
@@ -1,0 +1,182 @@
+/*
+ * File-Name: lhp_line.c
+ * File-Desc: line buffer services for lh_parse
+ * App-Name: lh_parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+#include <ctype.h> // iscntrl(), isspace()
+#include <stdbool.h> // true, false
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> // strlen()
+
+#include "lhp_metadata.h"
+#include "lhp_line.h"
+
+//-------------------------------------------------------------------
+// module internal variables : start
+//-------------------------------------------------------------------
+// Structure for parsing LAS fields: mnemonic_name, unit, value, desc
+struct field {
+  size_t idx;
+  char* buf;
+};
+
+//-------------------------------------------------------------------
+// module internal variables : finis
+//-------------------------------------------------------------------
+
+//-------------------------------------------------------------------
+// module internal functions : start
+//-------------------------------------------------------------------
+static void parse_mnemonic_name(struct field*, struct LhpLine*);
+static void parse_unit(struct field*, struct LhpLine*);
+static void parse_value(struct field*, struct LhpLine*);
+static void parse_desc(struct field*, struct LhpLine*);
+//-------------------------------------------------------------------
+// module internal functions : finis */
+//-------------------------------------------------------------------
+
+//-------------------------------------------------------------------
+// API: public-functions
+//-------------------------------------------------------------------
+struct LhpMetadata* lhp_metadata_init(size_t filesize)
+{
+  size_t arraysize = 0;
+  const size_t estimated_average_bytes_per_line = 55;
+
+  arraysize = filesize / estimated_average_bytes_per_line;
+  // printf("ARRAY-SIZE: [%zu]\n", arraysize);
+
+  struct LhpMetadata* lhp_metadata = NULL;
+  lhp_metadata = calloc(arraysize, sizeof(struct LhpMetadata));
+
+  if (!lhp_metadata) {
+    perror("calloc");
+    fprintf(stderr, "error: virtual memory exhausted: Unable to create lhp_metadata.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  return(lhp_metadata);
+}
+
+void lhp_data_init(struct LhpData* lhpdata, size_t filesize)
+{
+  static const size_t estimated_average_bytes_per_line = 55;
+
+  lhpdata->len = filesize / estimated_average_bytes_per_line;
+  // printf("ARRAY-SIZE: [%zu]\n", lhpdata->len);
+
+  lhpdata->array = calloc(lhpdata->len, sizeof(struct LhpMetadata));
+
+  if (!lhpdata->array) {
+    perror("calloc");
+    fprintf(stderr, "error: virtual memory exhausted: Unable to create lhp_metadata.\n");
+    exit(EXIT_FAILURE);
+  }
+}
+/*
+void parse_data_line(struct LhpMetadata* lhp_metadata, struct LhpLine* lhpline)
+{
+    parse_mnemonic_name(lhp_metadata, lhpline);
+    parse_unit(lhp_metadata, line);
+    parse_value(lhp_metadata, line);
+    parse_desc(lhp_metadata, line);
+}
+*/
+
+void parse_data_line(struct LhpMetadata* lhp_metadata, struct LhpLine* lhpline)
+{
+    struct field fld;
+    char* tofree;
+    tofree = fld.buf = strdup(lhpline->line);
+    enum fields { mnemonic_name, unit, value, desc, fields_end };
+
+    for (unsigned idx = 0; idx < fields_end; idx++) {
+      fld.idx = 0;
+
+      // parse_mnemonic_name(...)
+
+      if (idx == mnemonic_name) {
+        parse_mnemonic_name(&fld, lhpline);
+      }
+      else if (idx == unit) {
+        parse_unit(&fld, lhpline);
+      }
+      else if (idx == value) {
+        parse_value(&fld, lhpline);
+      }
+      else if (idx == desc) {
+        parse_desc(&fld, lhpline);
+      }
+
+      // Move lhpline->idx past the '.' delimiter.
+      lhpline->idx++;
+
+      fld.buf[fld.idx] = '\0';
+
+      // TODO: trim non-unit fields
+
+      // Copy buffer to metadata record field for the current field
+      if (idx == mnemonic_name) {
+        lhp_metadata->mnemonic_name = strdup(fld.buf);
+      }
+      else if (idx == unit) {
+        lhp_metadata->unit = strdup(fld.buf);
+      }
+      else if (idx == value) {
+        lhp_metadata->value = strdup(fld.buf);
+      }
+      else if (idx == desc) {
+        lhp_metadata->desc = strdup(fld.buf);
+      }
+    }
+
+    free(tofree);
+}
+
+// --------------------------------------------------------
+// Internal functions
+// --------------------------------------------------------
+static void parse_mnemonic_name(struct field* fld, struct LhpLine* lhpline)
+{
+    while (lhpline->line[lhpline->idx] != '.') {
+      fld->buf[fld->idx] = lhpline->line[lhpline->idx];
+      lhpline->idx++;
+      fld->idx++;
+    }
+}
+
+
+static void parse_unit(struct field* fld, struct LhpLine* lhpline)
+{
+    while (isspace(lhpline->line[lhpline->idx]) == false) {
+      fld->buf[fld->idx] = lhpline->line[lhpline->idx];
+      lhpline->idx++;
+      fld->idx++;
+    }
+}
+
+
+static void parse_value(struct field* fld, struct LhpLine* lhpline)
+{
+    while (lhpline->line[lhpline->idx] != ':') {
+      fld->buf[fld->idx] = lhpline->line[lhpline->idx];
+      lhpline->idx++;
+      fld->idx++;
+    }
+}
+
+
+static void parse_desc(struct field* fld, struct LhpLine* lhpline)
+{
+    while (lhpline->line[lhpline->idx] != '\0') {
+      fld->buf[fld->idx] = lhpline->line[lhpline->idx];
+      lhpline->idx++;
+      fld->idx++;
+    }
+}
+

--- a/src/lhp_parse.c
+++ b/src/lhp_parse.c
@@ -1,5 +1,5 @@
 /*
- * File-Name: lhp_parce.c
+ * File-Name: lhp_parse.c
  * File-Desc: parsing functions in lh_parse
  * App-Name: lh_parser
  * Project-Name: Las-Header-Parser
@@ -8,344 +8,94 @@
  */
 
 #include <ctype.h> // iscntrl(), isspace()
-#include <errno.h>
-#include <stdbool.h> // true, false
 #include <stdio.h> // FILE, fclose(), fopen(), fprintf(), perror()
 #include <stdlib.h> // malloc()
 #include <string.h> // strlen(), strncmp(), strncpy(), strdup()
-#include <sys/stat.h>
-#include <sys/types.h>
 
 
 #include "lhp_parse.h"
+#include "lhp_file.h"
+#include "lhp_line.h"
+#include "lhp_metadata.h"
 
-/*----------------------------------*/
-/* module private variables : start */
-/*----------------------------------*/
-/* use enum to make line_buf_size constant */
-enum { line_buf_size = 1024 };
-
+//-------------------------------------------------------------------
+// module private variables : start
+//-------------------------------------------------------------------
 static char *lhp_section_type = NULL;
-static char *lhp_field_buffer = NULL;
 static size_t rec_idx = 0;
-static size_t lhp_array_size = 0;
+//-------------------------------------------------------------------
+// module private variables : finis
+//-------------------------------------------------------------------
 
-// Index locations for the start of each field in a line.
-// static size_t line_idx = 0;
-static size_t line_indexes[4] = { 0, 0, 0, 0 };
-
-// 'lasm' is short for Log Ascii Standard Metadata
-struct lasm_record {
-    char *mnemonic_name;
-    char *unit;
-    char *value;
-    char *desc;
-};
-/*----------------------------------*/
-/* module private variables : finis */
-/*----------------------------------*/
-
-/*----------------------------------*/
-/* module private functions : start */
-/*----------------------------------*/
-static FILE *open_lhp_file(const char *lhp_filename);
-static off_t get_file_size(const char *lhp_filename);
-
-static size_t estimate_array_size(const off_t file_size);
-
-static void clean_up_end_of_line(char *line);
+//-------------------------------------------------------------------
+// module private functions : start
+//-------------------------------------------------------------------
+static void free_records(struct LhpMetadata* lasm_records, size_t lhp_array_size);
+static void display_records(struct LhpMetadata* lasm_records);
 static size_t parse_section_type(char *line);
+//-------------------------------------------------------------------
+// module private functions : finis
+//-------------------------------------------------------------------
 
-static void parse_mnemonic_name(char *line, struct lasm_record *lasm_records);
-static void parse_unit(char *line, struct lasm_record *lasm_records);
-static void parse_value(char *line, struct lasm_record *lasm_records);
-static void parse_desc(char *line, struct lasm_record *lasm_records);
 
-static void free_records(struct lasm_record *lasm_records);
-static void display_records(struct lasm_record *lasm_records);
-/*----------------------------------*/
-/* module private functions : finis */
-/*----------------------------------*/
-
-void read_las_file(const char *lhp_filename)
+void parse_las_file(const char *lhp_filename)
 {
-    FILE *fp;
-    char line[line_buf_size];
-    size_t line_len = 0;
-    off_t lhp_filesize = 0;
+    struct LhpFile lhpfile;
+    lhp_file_init(&lhpfile, lhp_filename);
 
-    lhp_filesize = get_file_size(lhp_filename);
-    printf("FILESIZE: [%lld]\n", lhp_filesize);
+    struct LhpLine lhpline;
+    lhp_line_init(&lhpline);
 
-    lhp_array_size = estimate_array_size(lhp_filesize);
-    printf("ARRAY-SIZE: [%zu]\n", lhp_array_size);
-    struct lasm_record *lasm_records = calloc(lhp_array_size, sizeof(struct lasm_record));
-    if (!lasm_records) {
-        fprintf(stderr, "error: virtual memory exhausted: Unable to create lasm_records array.\n");
-        exit(EXIT_FAILURE);
-    }
+    struct LhpData lhpdata;
+    lhp_data_init(&lhpdata, lhpfile.size);
 
-    
-    fp = open_lhp_file(lhp_filename);
+    // Memory: free(lasm_records); when done.
+    struct LhpMetadata *lasm_records = lhpdata.array;
 
-    if (fp == NULL) {
-        return;
-    }
-
-    while (fgets(line, line_buf_size, fp))
+    while (fgets(lhpline.line, lhpline.size, lhpfile.fp))
     {
-        size_t line_idx = 0;
-
-        clean_up_end_of_line(line);
-        if (parse_section_type(line)) {
+        lhp_line_config(&lhpline);
+        if (parse_section_type(lhpline.line)) {
           continue;
         }
 
-
-        line_len = strlen(line);
-
-        // Canidate content for fields: name, unit, value, desc
-        lhp_field_buffer = malloc(line_len);
-        if (lhp_field_buffer == NULL) {
-            perror("malloc");
-            exit(EXIT_FAILURE);
-        }
-
-        // Skip spaces at the beginning of the string.
-        while (isspace(line[line_idx])) {
-          line_idx++;
-        }
-
-        if (strncmp("#", line, 1) == 0) {
+        if (strncmp("#", lhpline.line, 1) == 0) {
           continue;
         }
 
         // ---------------------------------------------------------------------
         // Parse fields for the current line/record
         // ---------------------------------------------------------------------
-        parse_mnemonic_name(line, lasm_records);
-        parse_unit(line, lasm_records);
-        parse_value(line, lasm_records);
-        parse_desc(line, lasm_records);
+        parse_data_line(&lasm_records[rec_idx], &lhpline); 
 
         rec_idx = rec_idx + 1;
-
-        printf("REC-IDX: %zu, MAX: %zu\n", rec_idx, lhp_array_size);
-
-        // return;
     }
 
-    if (fclose(fp) == EOF) {
+    if (fclose(lhpfile.fp) == EOF) {
         perror("close");
     }
 
     display_records(lasm_records);
 
-    free_records(lasm_records);
+    free_records(lasm_records, lhpdata.len);
 }
 
 static size_t parse_section_type(char *line)
 {
-    size_t is_section = 0;    
-    size_t line_len = strlen(line);
+    size_t is_section = 0;
 
-    // Get the section type
     if (strncmp("~", line, 1) == 0) {
-        lhp_section_type = malloc(line_len);
-
-        if (lhp_section_type != NULL) {
-            strncpy(lhp_section_type, line, line_len);
-            if (lhp_section_type == NULL) {
-                perror("strncpy");
-                exit(EXIT_FAILURE);
-            }
-        }
-        is_section = 1;
-        printf("Section Type: [%s]\n\n", lhp_section_type);
+      lhp_section_type = strdup(line);
+      is_section = 1;
+      printf("Section Type: [%s]\n\n", lhp_section_type);
     }
     return(is_section);
 }
 
-void parse_mnemonic_name(char *line, struct lasm_record *lasm_records)
+
+void free_records(struct LhpMetadata *lasm_records, size_t lhp_array_size)
 {
-    size_t my_idx = 0;
-    char *my_buf;
-    char *tofree;
-    size_t line_idx = line_indexes[0];
-
-    tofree = my_buf = strdup(line);
-
-    while (line[line_idx] != '.') {
-      my_buf[my_idx] = line[line_idx];
-      line_idx++;
-      my_idx++;
-    }
-
-    // Move line_idx past the '.' delimiter.
-    line_idx++;
-    line_indexes[1] = line_idx;
-
-    // Copy buffer to mnemonic_name property
-    my_buf[my_idx] = '\0';
-    lasm_records[rec_idx].mnemonic_name = strdup(my_buf);
-
-    free(tofree);
-}
-
-void parse_unit(char *line, struct lasm_record *lasm_records)
-{
-    size_t my_idx = 0;
-    char *my_buf;
-    char *tofree;
-
-    if (line_indexes[1] == 0) {
-      parse_mnemonic_name(line, lasm_records);
-    }
-
-    size_t line_idx = line_indexes[1];
-
-    tofree = my_buf = strdup(line + line_idx);
-
-    while (isspace(line[line_idx]) == false) {
-      my_buf[my_idx] = line[line_idx];
-      line_idx++;
-      my_idx++;
-    }
-
-    // Move line_idx past the '.' delimiter.
-    line_idx++;
-    line_indexes[2] = line_idx;
-
-    // Copy buffer to mnemonic_name property
-    my_buf[my_idx] = '\0';
-    lasm_records[rec_idx].unit = strdup(my_buf);
-
-    free(tofree);
-}
-
-
-void parse_value(char *line, struct lasm_record *lasm_records)
-{
-    size_t my_idx = 0;
-    char *my_buf;
-    char *tofree;
-
-    if (line_indexes[2] == 0) {
-      parse_unit(line, lasm_records);
-    }
-
-    size_t line_idx = line_indexes[2];
-
-    tofree = my_buf = strdup(line + line_idx);
-
-    while (isspace(line[line_idx]) == true) {
-      line_idx++;
-    }
-
-    while (line[line_idx] != ':') {
-      my_buf[my_idx] = line[line_idx];
-      line_idx++;
-      my_idx++;
-    }
-
-    // Move line_idx past the '.' delimiter.
-    line_idx++;
-    line_indexes[3] = line_idx;
-
-    // Copy buffer to mnemonic_name property
-    my_buf[my_idx] = '\0';
-    lasm_records[rec_idx].value = strdup(my_buf);
-
-    free(tofree);
-}
-
-void parse_desc(char *line, struct lasm_record *lasm_records)
-{
-    size_t my_idx = 0;
-    char *my_buf;
-    char *tofree;
-
-    if (line_indexes[3] == 0) {
-      parse_value(line, lasm_records);
-    }
-
-    size_t line_idx = line_indexes[3];
-
-    tofree = my_buf = strdup(line + line_idx);
-
-    while (isspace(line[line_idx]) == true) {
-      line_idx++;
-    }
-
-    while (line[line_idx] != '\0') {
-      my_buf[my_idx] = line[line_idx];
-      line_idx++;
-      my_idx++;
-    }
-
-    // Copy buffer to mnemonic_name property
-    my_buf[my_idx] = '\0';
-    lasm_records[rec_idx].desc = strdup(my_buf);
-
-    free(tofree);
-}
-
-
-
-FILE *open_lhp_file(const char *lhp_filename)
-{
-    FILE *result;
-    result = fopen(lhp_filename, "r");
-
-    if (result == NULL)
-    {
-        fprintf(
-            stdout,
-            "INFO: config file [%s] not found. Using default settings.\n",
-            lhp_filename);
-        /* perror("fopen"); */
-    }
-    return result;
-}
-
-off_t get_file_size(const char *filename) {
-    struct stat st;
-
-    if (stat(filename, &st) == 0)
-        return st.st_size;
-
-    fprintf(stderr, "Cannot determine size of %s: %s\n",
-            filename, strerror(errno));
-
-    return -1;
-}
-
-size_t estimate_array_size(const off_t file_size) {
-  const size_t estimated_average_bytes_per_line = 55;
-
-  if (file_size > 0) {
-    return (size_t)file_size / estimated_average_bytes_per_line;
-  }
-  return 0;
-}
-
-static void clean_up_end_of_line(char *line)
-{
-    // Remove spaces and new-lines from the end of the line
-    size_t line_len = strlen(line);
-    for (size_t idx = line_len ; idx >= 1; idx--) {
-        if (iscntrl(line[idx]) || isspace(line[idx])) {
-            line[idx] = '\0';
-        }
-        else {
-            break;
-        }
-    }
-}
-
-
-void free_records(struct lasm_record *lasm_records)
-{
+    // printf("Array Size [%zu]\n", lhp_array_size);
     for (size_t free_idx = 0; free_idx < lhp_array_size; free_idx++) {
         // printf("releasing memory for rec_idx [%ld]\n", free_idx);
         free(lasm_records[free_idx].mnemonic_name);
@@ -356,7 +106,7 @@ void free_records(struct lasm_record *lasm_records)
 }
 
 
-void display_records(struct lasm_record *lasm_records)
+void display_records(struct LhpMetadata *lasm_records)
 {
     for (size_t idx = 0; idx < rec_idx; idx++) {
         // display record

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
     char *file_to_parse = get_filename_arg();
     printf("filename: [%s]\n", file_to_parse);
 
-    read_las_file(file_to_parse);
+    parse_las_file(file_to_parse);
     
     release_arg_memory();
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,6 +1,4 @@
-/*
- * File-Name: test_main.c
- * File-Desc: Test file for lh_parser
+/* * File-Name: test_main.c * File-Desc: Test file for lh_parser
  * App-Name: las-header-parser
  * Project-Name: Las-Header-Parser
  * Copyright: Copyright (c) 2020, DC Slagel
@@ -10,10 +8,11 @@
 #include <stdio.h>  // printf
 #include <stdlib.h> // calloc, exit, EXIT_SUCCESS
 
+#include "lhp_file.c"
+#include "lhp_line.c"
+#include "lhp_metadata.c"
 #include "lhp_parse.c"
 
-// resets lhp_parser.line_indexes[]
-void reset_line_indexes(void);
 
 int test_parse_mnemonic(void); 
 int test_lhp_section_type_is_null(void);
@@ -24,18 +23,12 @@ static char *test_rec_001 = "VERS.  3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0";
 static char *test_rec_002 = "STRT .M      1670.0000              : First Index Value";
 static char *test_rec_003 = "STRT .M      1670.0000              : ";
 
-// Configure array of records for testing
-static size_t test_array_size = 1;
-struct lasm_record *lasm_records = NULL;
+// Configure a record for testing
+struct LhpMetadata lasm_record;
 
-// resets lhp_parser.line_indexes[]
-void reset_line_indexes(void)
-{
-  line_indexes[0] = 0;
-  line_indexes[1] = 0;
-  line_indexes[2] = 0;
-  line_indexes[3] = 0;
-}
+// Configure line object
+// Add the actual line in the specific test case
+struct LhpLine lhpline;
 
 int test_lhp_section_type_is_null(void) {
   if (lhp_section_type == NULL) {
@@ -64,72 +57,96 @@ int test_section_type_is_empty(void) {
 }
 
 int test_parse_mnemonic(void) {
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
-  parse_mnemonic_name(test_rec_001, lasm_records);
-  if (strcmp(lasm_records[0].mnemonic_name, "VERS") == 0) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = "VERS";
+  if (strcmp(lasm_record.mnemonic_name, want) == 0) {
     return(1);
   } else {
-    printf("FAILED: test_parse_mnemonic_name: actual: [%s]\n", lasm_records[1].mnemonic_name);
+    printf(
+        "FAILED: test_parse_mnemonic_name:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.unit, want);
     return(0);
   }
   return(1);
 }
 
 int test_parse_empty_unit(void) {
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
-  parse_unit(test_rec_001, lasm_records);
-  if (strcmp(lasm_records[0].unit, "") == 0) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = "";
+  if (strcmp(lasm_record.unit, want) == 0) {
     return(1);
   } else {
-    printf("FAILED: test_parse_unit: actual: [%s]\n", lasm_records[1].unit);
+    printf(
+        "FAILED: test_parse_unit:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.unit, want);
     return(0);
   }
   return(1);
 }
 
 int test_parse_m_unit(void) {
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
-  parse_unit(test_rec_002, lasm_records);
-  if (strcmp(lasm_records[0].unit, "M") == 0) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_002;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = "M";
+  if (strcmp(lasm_record.unit, want) == 0) {
     return(1);
   } else {
-    printf("FAILED: test_parse_unit: actual: [%s]\n", lasm_records[1].unit);
+    printf(
+        "FAILED: test_parse_unit:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.unit, want);
     return(0);
   }
   return(1);
 }
 
 int test_parse_value(void) {
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
-  parse_value(test_rec_001, lasm_records);
-  if (strcmp(lasm_records[0].value, "3.0 ") == 0) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = " 3.0 ";
+  if (strcmp(lasm_record.value, want) == 0) {
     return(1);
   } else {
-    printf("FAILED: test_parse_value: actual: [%s]\n", lasm_records[1].value);
+    printf(
+        "FAILED: test_parse_value:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.value, want);
     return(0);
   }
   return(1);
 }
 
 int test_parse_desc(void) {
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
-  parse_desc(test_rec_001, lasm_records);
-  if (strcmp(lasm_records[0].desc, "CWLS LOG ASCII STANDARD -VERSION 3.0") == 0) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = " CWLS LOG ASCII STANDARD -VERSION 3.0";
+  if (strcmp(lasm_record.desc, want) == 0) {
     return(1);
   } else {
-    printf("FAILED: test_parse_desc: actual: [%s]\n", lasm_records[1].desc);
+    printf(
+        "FAILED: test_parse_desc:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.desc, want);
     return(0);
   }
   return(1);
 }
 
 int test_parse_empty_desc(void) {
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
-  parse_desc(test_rec_003, lasm_records);
-  if (strcmp(lasm_records[0].desc, "") == 0) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_003;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = " ";
+  if (strcmp(lasm_record.desc, want) == 0) {
     return(1);
   } else {
-    printf("FAILED: test_parse_desc: actual: [%s]\n", lasm_records[1].desc);
+    printf(
+        "FAILED: test_parse_desc:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.desc, want);
     return(0);
   }
   return(1);
@@ -141,7 +158,7 @@ int main(void)
   int failed = 0;
 
   /*
-  struct lasm_record *lasm_records = calloc(test_array_size, sizeof(struct lasm_record));
+  struct lasm_record *lasm_records = calloc(test_file_size, sizeof(struct lasm_record));
   if (!lasm_records) {
       fprintf(stderr, "error: virtual memory exhausted: Unable to create lasm_records array.\n");
       exit(EXIT_FAILURE);
@@ -191,19 +208,12 @@ int main(void)
     failed = failed + 1;
   }
 
-  // Test a different line 
-  // So rest line indexes
-  reset_line_indexes();
-
   if (test_parse_m_unit()) {
     passed = passed + 1;
   } else {
     failed = failed + 1;
   }
 
-  // Test a different line 
-  // So rest line indexes
-  reset_line_indexes();
   if (test_parse_empty_desc()) {
     passed = passed + 1;
   } else {


### PR DESCRIPTION
Resolves #9 `Refactor lhp_parser.c's read_las_file function.`

    Refactor main parser
    
    - Update test file to handle the refactored parsing
    - Refactor LAS field parsing
    - Move detail parse functions to lhp_metadata.c
    - Change parse_.. funcs parameters
    - Move metadata services to lhp_metadata.c
    - Move line iteration config to lhp_line.c
    - Move initial line services to lhp_line.c
    - Change lhp_parse to use lhp_file
    - Move file functions to lhp_file.c
