### PR TITLE
Separate test definitions from test engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,11 @@ RM = rm -fv
 # Project variables
 # ------------------------------------------------------------------------------
 PRG       = lh_parser
-SRCS      = lhp_args.c lhp_file.c lhp_line.c lhp_metadata.c lhp_parse.c main.c
-OBJS      = $(subst .c,.o,$(SRCS))
+SRCS      = lhp_args.c lhp_file.c lhp_line.c lhp_metadata.c lhp_parse.c
+MAIN_SRCS = $(SRCS) main.c
+TEST_SRCS = $(SRCS) tests/lhp_test_parse.c tests/test_main.c
+MAIN_OBJS      = $(subst .c,.o,$(MAIN_SRCS))
+TEST_OBJS      = $(subst .c,.o,$(TEST_SRCS))
 LAS_FILE  = dev_example_30.las
 
 
@@ -60,7 +63,7 @@ all: $(PRG)
 
 $(PRG) : $(DIR_REL)/$(PRG)
 
-$(DIR_REL)/$(PRG): $(SRCS)
+$(DIR_REL)/$(PRG): $(MAIN_SRCS)
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $^ -o $(DIR_REL)/$(PRG)
 
@@ -78,7 +81,7 @@ clean_rel:
 # ------------------------------------------------------------------------------
 $(PRG)_dev : $(DIR_DEV)/lh_parser
 
-$(DIR_DEV)/$(PRG): $(SRCS)
+$(DIR_DEV)/$(PRG): $(MAIN_SRCS)
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(DEBUG) $^ -o $(DIR_DEV)/lh_parser
 
@@ -102,9 +105,9 @@ install: $(PRG)
 # ------------------------------------------------------------------------------
 test: $(DIR_TEST)/test_main
 
-$(DIR_TEST)/test_main: tests/test_main.c $(SRCS)
+$(DIR_TEST)/test_main: $(TEST_SRCS)
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -I src tests/test_main.c -o $(DIR_TEST)/test_main
+	$(CC) $(CFLAGS) -I src $^ -o $(DIR_TEST)/test_main
 
 run_test:
 	$(DIR_TEST)/test_main

--- a/include/lhp.h
+++ b/include/lhp.h
@@ -12,5 +12,8 @@
 
 #include "lhp_args.h"
 #include "lhp_parse.h"
+#include "lhp_line.h"
+#include "lhp_parse.h"
+#include "lhp_metadata.h"
 
 #endif /* LHP_H */

--- a/include/lhp_test_parse.h
+++ b/include/lhp_test_parse.h
@@ -1,0 +1,21 @@
+/*
+ * File-Name: lhp_test_parser.h
+ * File-Desc: Header file for test parser functions for lh_parser
+ * App-Name: las-header-parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+
+#ifndef LHP_TEST_PARSE_H
+#define LHP_TEST_PARSE_H
+
+int test_parse_mnemonic(void);
+int test_parse_empty_unit(void);
+int test_parse_value(void);
+int test_parse_desc(void);
+int test_parse_m_unit(void);
+int test_parse_empty_desc(void);
+
+#endif /* LHP_TEST_PARSE_H */

--- a/tests/lhp_test_parse.c
+++ b/tests/lhp_test_parse.c
@@ -1,0 +1,125 @@
+/* 
+ * File-Name: lhp_test_parser.c
+ * File-Desc: Test parser functions for lh_parser
+ * App-Name: las-header-parser
+ * Project-Name: Las-Header-Parser
+ * Copyright: Copyright (c) 2020, DC Slagel
+ * License-Identifier: MIT
+ */
+
+#include <stdio.h>  // printf
+#include <stdlib.h> // calloc, exit, EXIT_SUCCESS
+#include <string.h> // strcmp()
+
+#include "lhp.h"
+#include "lhp_test_parse.h"
+
+static char *test_rec_001 = "VERS.  3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0";
+static char *test_rec_002 = "STRT .M      1670.0000              : First Index Value";
+static char *test_rec_003 = "STRT .M      1670.0000              : ";
+
+
+// Configure a record for testing
+struct LhpMetadata lasm_record;
+
+// Configure line object
+// Add the actual line in the specific test case
+struct LhpLine lhpline;
+
+
+int test_parse_mnemonic(void) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = "VERS";
+  if (strcmp(lasm_record.mnemonic_name, want) == 0) {
+    return(1);
+  } else {
+    printf(
+        "FAILED: test_parse_mnemonic_name:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.unit, want);
+    return(0);
+  }
+  return(1);
+}
+
+int test_parse_empty_unit(void) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = "";
+  if (strcmp(lasm_record.unit, want) == 0) {
+    return(1);
+  } else {
+    printf(
+        "FAILED: test_parse_unit:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.unit, want);
+    return(0);
+  }
+  return(1);
+}
+
+int test_parse_m_unit(void) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_002;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = "M";
+  if (strcmp(lasm_record.unit, want) == 0) {
+    return(1);
+  } else {
+    printf(
+        "FAILED: test_parse_unit:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.unit, want);
+    return(0);
+  }
+  return(1);
+}
+
+int test_parse_value(void) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = " 3.0 ";
+  if (strcmp(lasm_record.value, want) == 0) {
+    return(1);
+  } else {
+    printf(
+        "FAILED: test_parse_value:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.value, want);
+    return(0);
+  }
+  return(1);
+}
+
+int test_parse_desc(void) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_001;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = " CWLS LOG ASCII STANDARD -VERSION 3.0";
+  if (strcmp(lasm_record.desc, want) == 0) {
+    return(1);
+  } else {
+    printf(
+        "FAILED: test_parse_desc:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.desc, want);
+    return(0);
+  }
+  return(1);
+}
+
+int test_parse_empty_desc(void) {
+  lhp_line_init(&lhpline);
+  lhpline.line = test_rec_003;
+  parse_data_line(&lasm_record, &lhpline);
+  char* want = " ";
+  if (strcmp(lasm_record.desc, want) == 0) {
+    return(1);
+  } else {
+    printf(
+        "FAILED: test_parse_desc:\n\tactual: [%s]\n\twant: [%s]\n",
+        lasm_record.desc, want);
+    return(0);
+  }
+  return(1);
+}
+

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,187 +1,22 @@
-/* * File-Name: test_main.c * File-Desc: Test file for lh_parser
+/* 
+ * File-Name: test_main.c
+ * File-Desc: Test file for lh_parser
  * App-Name: las-header-parser
  * Project-Name: Las-Header-Parser
  * Copyright: Copyright (c) 2020, DC Slagel
  * License-Identifier: MIT
  */
 
-#include <stdio.h>  // printf
-#include <stdlib.h> // calloc, exit, EXIT_SUCCESS
+#include <stdio.h>  // printf()
+#include <stdlib.h> // exit, EXIT_SUCCESS
 
-#include "lhp_file.c"
-#include "lhp_line.c"
-#include "lhp_metadata.c"
-#include "lhp_parse.c"
+#include "lhp_test_parse.h"
 
-
-int test_parse_mnemonic(void); 
-int test_lhp_section_type_is_null(void);
-int test_section_type_is_ver(void);
-int test_section_type_is_empty(void);
-
-static char *test_rec_001 = "VERS.  3.0 : CWLS LOG ASCII STANDARD -VERSION 3.0";
-static char *test_rec_002 = "STRT .M      1670.0000              : First Index Value";
-static char *test_rec_003 = "STRT .M      1670.0000              : ";
-
-// Configure a record for testing
-struct LhpMetadata lasm_record;
-
-// Configure line object
-// Add the actual line in the specific test case
-struct LhpLine lhpline;
-
-int test_lhp_section_type_is_null(void) {
-  if (lhp_section_type == NULL) {
-    return(1);
-  } else {
-    return(0);
-  }
-}
-
-int test_section_type_is_ver(void) {
-  parse_section_type("~VER");
-  if (strcmp(lhp_section_type, "~VER") == 0) {
-    return(1);
-  } else {
-    return(0);
-  }
-}
-
-int test_section_type_is_empty(void) {
-  memset(lhp_section_type,0,strlen(lhp_section_type));
-  if (strcmp(lhp_section_type, "") == 0) {
-    return(1);
-  } else {
-    return(0);
-  }
-}
-
-int test_parse_mnemonic(void) {
-  lhp_line_init(&lhpline);
-  lhpline.line = test_rec_001;
-  parse_data_line(&lasm_record, &lhpline);
-  char* want = "VERS";
-  if (strcmp(lasm_record.mnemonic_name, want) == 0) {
-    return(1);
-  } else {
-    printf(
-        "FAILED: test_parse_mnemonic_name:\n\tactual: [%s]\n\twant: [%s]\n",
-        lasm_record.unit, want);
-    return(0);
-  }
-  return(1);
-}
-
-int test_parse_empty_unit(void) {
-  lhp_line_init(&lhpline);
-  lhpline.line = test_rec_001;
-  parse_data_line(&lasm_record, &lhpline);
-  char* want = "";
-  if (strcmp(lasm_record.unit, want) == 0) {
-    return(1);
-  } else {
-    printf(
-        "FAILED: test_parse_unit:\n\tactual: [%s]\n\twant: [%s]\n",
-        lasm_record.unit, want);
-    return(0);
-  }
-  return(1);
-}
-
-int test_parse_m_unit(void) {
-  lhp_line_init(&lhpline);
-  lhpline.line = test_rec_002;
-  parse_data_line(&lasm_record, &lhpline);
-  char* want = "M";
-  if (strcmp(lasm_record.unit, want) == 0) {
-    return(1);
-  } else {
-    printf(
-        "FAILED: test_parse_unit:\n\tactual: [%s]\n\twant: [%s]\n",
-        lasm_record.unit, want);
-    return(0);
-  }
-  return(1);
-}
-
-int test_parse_value(void) {
-  lhp_line_init(&lhpline);
-  lhpline.line = test_rec_001;
-  parse_data_line(&lasm_record, &lhpline);
-  char* want = " 3.0 ";
-  if (strcmp(lasm_record.value, want) == 0) {
-    return(1);
-  } else {
-    printf(
-        "FAILED: test_parse_value:\n\tactual: [%s]\n\twant: [%s]\n",
-        lasm_record.value, want);
-    return(0);
-  }
-  return(1);
-}
-
-int test_parse_desc(void) {
-  lhp_line_init(&lhpline);
-  lhpline.line = test_rec_001;
-  parse_data_line(&lasm_record, &lhpline);
-  char* want = " CWLS LOG ASCII STANDARD -VERSION 3.0";
-  if (strcmp(lasm_record.desc, want) == 0) {
-    return(1);
-  } else {
-    printf(
-        "FAILED: test_parse_desc:\n\tactual: [%s]\n\twant: [%s]\n",
-        lasm_record.desc, want);
-    return(0);
-  }
-  return(1);
-}
-
-int test_parse_empty_desc(void) {
-  lhp_line_init(&lhpline);
-  lhpline.line = test_rec_003;
-  parse_data_line(&lasm_record, &lhpline);
-  char* want = " ";
-  if (strcmp(lasm_record.desc, want) == 0) {
-    return(1);
-  } else {
-    printf(
-        "FAILED: test_parse_desc:\n\tactual: [%s]\n\twant: [%s]\n",
-        lasm_record.desc, want);
-    return(0);
-  }
-  return(1);
-}
 
 int main(void)
 {
   int passed = 0;
   int failed = 0;
-
-  /*
-  struct lasm_record *lasm_records = calloc(test_file_size, sizeof(struct lasm_record));
-  if (!lasm_records) {
-      fprintf(stderr, "error: virtual memory exhausted: Unable to create lasm_records array.\n");
-      exit(EXIT_FAILURE);
-  }
-  */
-
-  if (test_lhp_section_type_is_null()) {
-    passed = passed + 1;
-  } else {
-    failed = failed + 1;
-  }
-
-  if (test_section_type_is_ver()) {
-    passed = passed + 1;
-  } else {
-    failed = failed + 1;
-  }
-
-  if (test_section_type_is_empty()) {
-    passed = passed + 1;
-  } else {
-    failed = failed + 1;
-  }
 
   // Test a line
   if (test_parse_mnemonic()) {


### PR DESCRIPTION
This is a step toward a more flexible test environment.

- Change Makefile to handle sources with separate main files (main.c, test_main.c)
- Temporarily remove section-header tests. Separating the tests from test_main.c revealed a scope issue.  This will be fixed in https://github.com/dcslagel/las-header-parser-c/issues/38
`Add a data structure section header information`
- Update lhp.h to include the header files introduced in other 0.0.3 pull-requests.
- create new include/lhp_test_parse.h and tests/lhp_test_parse.c to hold the test definitions.


Resolves #31 `Test : Refactor: Move the test definitions to separate files from the test engine.`